### PR TITLE
Feature/prettier end of line fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,11 @@ module.exports = {
     "plugin:react-native-a11y/basic",
   ],
   rules: {
-    "prettier/prettier": ["error"],
+    "prettier/prettier": [
+      "error",
+      {
+        endofLine: "auto",
+      },
+    ],
   },
 };

--- a/app.json
+++ b/app.json
@@ -8,9 +8,9 @@
     ],
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./assets/icon.png",
+    "icon": "./src/assets/icon.png",
     "splash": {
-      "image": "./assets/splash.png",
+      "image": "./src/assets/splash.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-preset-expo": "~8.1.0",
     "eslint": "~7.2.0",
     "eslint-config-airbnb": "~18.1.0",
-    "eslint-config-prettier": "~6.11.0",
+    "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "~2.20.2",
     "eslint-plugin-prettier": "~3.1.3",
     "eslint-plugin-react": "~7.20.0",


### PR DESCRIPTION
Had hundreds of Prettier errors due to Prettier endOfLine conflicting with VS Code's end of line sequence settings. Adib Khan said I could change the prettier rules to include "endOfLine":"auto" since he doesn't care which end of line sequence any of us use so I did change the rules in .eslintrc.js.

Images:
ERROR:
![error](https://user-images.githubusercontent.com/55326667/84064525-bd07a100-a990-11ea-9dc8-aac1f98f2068.png)

![adib_approval](https://user-images.githubusercontent.com/55326667/84064523-bc6f0a80-a990-11ea-8fdd-ec3c261c3a60.png)

ALL GOOD:
![all_good](https://user-images.githubusercontent.com/55326667/84064524-bd07a100-a990-11ea-96a0-e03462ed494f.png)



