### PR TITLE
Added Answer Feedback for Math Questions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-native-screens": "~3.15.0",
         "react-native-slider": "^0.11.0",
         "react-native-step-indicator": "^1.0.3",
+        "react-native-toast-message": "^2.1.5",
         "react-native-vector-icons": "9.2.0",
         "react-native-web": "~0.18.7"
       },
@@ -14889,6 +14890,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-toast-message": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.1.5.tgz",
+      "integrity": "sha512-mk3rELtBEhrhWBCN6CTaw0gypgL9ZNauX3xx1LUs4uee9vc0pVsghrKxO57vroUCcNL2hDeZSLJWdQNMCkGeaQ==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-vector-icons": {
       "version": "9.2.0",
       "resolved": "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz",
@@ -28078,6 +28088,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.yarnpkg.com/react-native-step-indicator/-/react-native-step-indicator-1.0.3.tgz",
       "integrity": "sha512-WwTb6lpJl0T7MV59sus1utoEQuqbuWHq6V0R0iDWmlPRFjM0qirhTNTS5on1+V9Qmc9dsUCT380/mRgDF+U6zw==",
+      "requires": {}
+    },
+    "react-native-toast-message": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.1.5.tgz",
+      "integrity": "sha512-mk3rELtBEhrhWBCN6CTaw0gypgL9ZNauX3xx1LUs4uee9vc0pVsghrKxO57vroUCcNL2hDeZSLJWdQNMCkGeaQ==",
       "requires": {}
     },
     "react-native-vector-icons": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-native-screens": "~3.15.0",
     "react-native-slider": "^0.11.0",
     "react-native-step-indicator": "^1.0.3",
+    "react-native-toast-message": "^2.1.5",
     "react-native-vector-icons": "9.2.0",
     "react-native-web": "~0.18.7"
   },

--- a/src/screens/Game/Gameplay.jsx
+++ b/src/screens/Game/Gameplay.jsx
@@ -6,6 +6,8 @@ import React, { useState } from "react";
 import { View, StyleSheet, AsyncStorage } from "react-native";
 import { Button } from "react-native-elements";
 import PropTypes from "prop-types";
+import Toast from 'react-native-toast-message'
+
 import ProgressBar from "../../components/ProgressBar";
 import getProblem from "../../scripts/game-logic";
 import Text from "../../components/Text";
@@ -132,6 +134,7 @@ function Gameplay({ route, navigation }) {
   }
 
   function checkAnswer(choiceValue, skip=false) {
+    let correct = false;
     if (!answered) {
       const timeToAnswer = pBar.current.getCurrentTime() - remainingTime;
 
@@ -150,17 +153,33 @@ function Gameplay({ route, navigation }) {
 
         if (skip == false && choiceValue === problem.solution) {
           difficultyScore = Math.min(difficultyScore + 10, 499);
-        }
+          Toast.show({
+            type: 'success',
+            text1: 'Correct!'
+          });
+          correct = true;
 
+        } else {
+          Toast.show({
+            type: 'error',
+            text1: 'Wrong. Please Try Again!'
+          });
+        }
+        
         storeDifficultyScore(difficultyScore.toString());
       });
 
       setRemainingTime(pBar.current.getCurrentTime());
       setAnswered(true);
 
-      setTimeout(() => {
-        getNewProblem();
-      }, 500);
+      if (choiceValue === problem.solution) {
+        setTimeout(() => {
+          getNewProblem();
+        }, 500);
+      } else {
+        setAnswered(false);
+        setPicked(0);
+      }
     }
   }
 
@@ -206,6 +225,11 @@ function Gameplay({ route, navigation }) {
         }}
         ref={pBar}
         shouldNotRender
+      />
+      <Toast 
+        visibilityTime={1000}
+        position='bottom'
+        bottomOffset={60}
       />
       <View style={styles.textContainer}>
           <Text style={styles.title}>Tap the answer to the math problem.</Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6794,6 +6794,11 @@
   "resolved" "https://registry.yarnpkg.com/react-native-step-indicator/-/react-native-step-indicator-1.0.3.tgz"
   "version" "1.0.3"
 
+"react-native-toast-message@^2.1.5":
+  "integrity" "sha512-mk3rELtBEhrhWBCN6CTaw0gypgL9ZNauX3xx1LUs4uee9vc0pVsghrKxO57vroUCcNL2hDeZSLJWdQNMCkGeaQ=="
+  "resolved" "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.1.5.tgz"
+  "version" "2.1.5"
+
 "react-native-vector-icons@>6.6.0", "react-native-vector-icons@9.2.0":
   "integrity" "sha512-wKYLaFuQST/chH3AJRjmOLoLy3JEs1JR6zMNgTaemFpNoXs0ztRnTxcxFD9xhX7cJe1/zoN5BpQYe7kL0m5yyA=="
   "resolved" "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz"


### PR DESCRIPTION
This PR addresses issue #120. Added only the question feedback for the Math questions since that was the only type of question that the app knows of the correct answer. The feature incorporates the following logic to the math questions

1. If the answer is correct, a success toast pops up
2. If the answer is incorrect, a incorrect toast pops up and the question stays where it is until the user picks a correct answer or the time runs out. 

Also the following dependencies were installed `react-native-toast-message` in order to add the Toast. 