### PR TITLE
Tyler/187 frontend reading analytics and skip section

### DIFF
--- a/src/hooks/useReadingProblems.ts
+++ b/src/hooks/useReadingProblems.ts
@@ -5,7 +5,7 @@ export default function useReadingProblems({ navigation, route }) {
   const [storyArray, setStoryArray] = useState(getStoryArray());
   const [page, setPage] = useState(0);
   const [passagesRead, setPassagesRead] = useState(0);
-  const [skipped, setSkipped] = useState(false);
+  const paragraph = storyArray[page];
 
   const incrementPassagesRead = useCallback(() => {
     setPassagesRead((prev) => prev + 1);
@@ -21,21 +21,21 @@ export default function useReadingProblems({ navigation, route }) {
     incrementPassagesRead();
   };
 
-  const paragraph = storyArray[page];
-
-  const onTimeComplete = useCallback(() => {
-    const statistics = { passagesRead, completed: !skipped };
-    // checking that statistics are correct:
-    console.log("statistics: ", statistics);
-    console.log("completed: ", statistics.completed);
-    console.log("passagesRead: ", statistics.passagesRead);
-    navigation.navigate(...route.params.nextScreenArgs);
-  }, [navigation, route.params.nextScreenArgs, skipped, passagesRead]);
+  const onTimeComplete = useCallback(
+    (skipped) => {
+      const statistics = { passagesRead, completed: !skipped };
+      // checking that statistics are correct:
+      console.log("statistics: ", statistics);
+      console.log("completed: ", statistics.completed);
+      console.log("passagesRead: ", statistics.passagesRead);
+      navigation.replace(...route.params.nextScreenArgs);
+    },
+    [navigation, route.params.nextScreenArgs, passagesRead],
+  );
 
   return {
     paragraph,
     nextParagraph,
     onTimeComplete,
-    setSkipped,
   };
 }

--- a/src/hooks/useReadingProblems.ts
+++ b/src/hooks/useReadingProblems.ts
@@ -1,15 +1,15 @@
 import { useState, useCallback } from "react";
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import getStoryArray from "../assets/stories";
+import { RootStackParamList } from "../types";
 
-export default function useReadingProblems({ navigation, route }) {
+type Props = NativeStackScreenProps<RootStackParamList, "ReadingMain">;
+
+export default function useReadingProblems({ navigation, route }: Props) {
   const [storyArray, setStoryArray] = useState(getStoryArray());
   const [page, setPage] = useState(0);
   const [passagesRead, setPassagesRead] = useState(0);
   const paragraph = storyArray[page];
-
-  const incrementPassagesRead = useCallback(() => {
-    setPassagesRead((prev) => prev + 1);
-  }, []);
 
   const nextParagraph = () => {
     if (storyArray.length - 1 === page) {
@@ -18,16 +18,12 @@ export default function useReadingProblems({ navigation, route }) {
     } else {
       setPage(page + 1);
     }
-    incrementPassagesRead();
+    setPassagesRead((prev) => prev + 1);
   };
 
   const onTimeComplete = useCallback(
-    (skipped) => {
-      const statistics = { passagesRead, completed: !skipped };
-      // checking that statistics are correct:
-      console.log("statistics: ", statistics);
-      console.log("completed: ", statistics.completed);
-      console.log("passagesRead: ", statistics.passagesRead);
+    (skipped: boolean) => {
+      const statistics = { passagesRead, completed: !skipped }; // eslint-disable-line
       navigation.replace(...route.params.nextScreenArgs);
     },
     [navigation, route.params.nextScreenArgs, passagesRead],

--- a/src/hooks/useReadingProblems.ts
+++ b/src/hooks/useReadingProblems.ts
@@ -1,0 +1,41 @@
+import { useState, useCallback } from "react";
+import getStoryArray from "../assets/stories";
+
+export default function useReadingProblems({ navigation, route }) {
+  const [storyArray, setStoryArray] = useState(getStoryArray());
+  const [page, setPage] = useState(0);
+  const [passagesRead, setPassagesRead] = useState(0);
+  const [skipped, setSkipped] = useState(false);
+
+  const incrementPassagesRead = useCallback(() => {
+    setPassagesRead((prev) => prev + 1);
+  }, []);
+
+  const nextParagraph = () => {
+    if (storyArray.length - 1 === page) {
+      setStoryArray(getStoryArray());
+      setPage(0);
+    } else {
+      setPage(page + 1);
+    }
+    incrementPassagesRead();
+  };
+
+  const paragraph = storyArray[page];
+
+  const onTimeComplete = useCallback(() => {
+    const statistics = { passagesRead, completed: !skipped };
+    // checking that statistics are correct:
+    console.log("statistics: ", statistics);
+    console.log("completed: ", statistics.completed);
+    console.log("passagesRead: ", statistics.passagesRead);
+    navigation.navigate(...route.params.nextScreenArgs);
+  }, [navigation, route.params.nextScreenArgs, skipped, passagesRead]);
+
+  return {
+    paragraph,
+    nextParagraph,
+    onTimeComplete,
+    setSkipped,
+  };
+}

--- a/src/screens/Game/ReadingMain.tsx
+++ b/src/screens/Game/ReadingMain.tsx
@@ -36,14 +36,16 @@ const styles = StyleSheet.create({
   },
 });
 
-const TOTAL_TIME = gameDescriptions.Reading.minutes * 60;
+const TOTAL_TIME = gameDescriptions.Reading.minutes * 5;
 type Props = NativeStackScreenProps<RootStackParamList, "ReadingMain">;
 
 export default function ReadingMain({ navigation, route }: Props) {
   const dispatch = useDispatch();
 
-  const { paragraph, nextParagraph, onTimeComplete, setSkipped } =
-    useReadingProblems({ navigation, route });
+  const { paragraph, nextParagraph, onTimeComplete } = useReadingProblems({
+    navigation,
+    route,
+  });
 
   const nextSection = () => {
     Alert.alert(
@@ -57,10 +59,8 @@ export default function ReadingMain({ navigation, route }: Props) {
         {
           text: "Yes",
           onPress: () => {
-            setSkipped(true);
-            onTimeComplete();
             dispatch(unpause());
-            navigation.navigate("TriviaMain");
+            onTimeComplete(true);
           },
         },
       ],
@@ -73,7 +73,7 @@ export default function ReadingMain({ navigation, route }: Props) {
       <ProgressBar
         maxSeconds={TOTAL_TIME}
         redThreshold={30}
-        onTimeComplete={onTimeComplete}
+        onTimeComplete={() => onTimeComplete(false)}
       />
       <Text style={styles.instructions}>Read the passage aloud.</Text>
       <ScrollView contentContainerStyle={styles.articleWrapper}>

--- a/src/screens/Game/ReadingMain.tsx
+++ b/src/screens/Game/ReadingMain.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useCallback } from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
+import { ScrollView, StyleSheet, View , Alert } from "react-native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { useDispatch } from "react-redux";
 import getStoryArray from "../../assets/stories";
 import Button from "../../components/Button";
 import ProgressBar from "../../components/ProgressBar";
 import Text from "../../components/Text";
 import { RootStackParamList } from "../../types";
 import gameDescriptions from "../Stacks/gameDescriptions";
+import { unpause } from "../../redux/reducers/pauseReducer";
 
 const styles = StyleSheet.create({
   root: {
@@ -54,9 +56,27 @@ export default function ReadingMain({ navigation, route }: Props) {
     }
   };
 
-  const nextArticle = () => {
-    setStoryArray(getStoryArray());
-    setPage(0);
+  const dispatch = useDispatch();
+
+  const nextSection = () => {
+    Alert.alert(
+      "Skip Reading Section",
+      "Are you sure you want to skip the Reading section?",
+      [
+        {
+          text: "Cancel",
+          style: "cancel",
+        },
+        {
+          text: "Yes",
+          onPress: () => {
+            dispatch(unpause());
+            navigation.navigate("TriviaMain");
+          },
+        },
+      ],
+      { cancelable: false },
+    );
   };
 
   const paragraph = storyArray[page];
@@ -83,8 +103,8 @@ export default function ReadingMain({ navigation, route }: Props) {
         shouldNotPlay
       />
       <Button
-        title="Skip Article"
-        onPress={nextArticle}
+        title="Skip Section"
+        onPress={nextSection}
         buttonStyle={{ marginBottom: 40 }}
       />
     </View>

--- a/src/screens/Game/ReadingMain.tsx
+++ b/src/screens/Game/ReadingMain.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useCallback } from "react";
-import { ScrollView, StyleSheet, View , Alert } from "react-native";
+import { ScrollView, StyleSheet, View, Alert } from "react-native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useDispatch } from "react-redux";
-import getStoryArray from "../../assets/stories";
+
 import Button from "../../components/Button";
 import ProgressBar from "../../components/ProgressBar";
 import Text from "../../components/Text";
+import useReadingProblems from "../../hooks/useReadingProblems";
 import { RootStackParamList } from "../../types";
 import gameDescriptions from "../Stacks/gameDescriptions";
 import { unpause } from "../../redux/reducers/pauseReducer";
@@ -40,23 +40,10 @@ const TOTAL_TIME = gameDescriptions.Reading.minutes * 60;
 type Props = NativeStackScreenProps<RootStackParamList, "ReadingMain">;
 
 export default function ReadingMain({ navigation, route }: Props) {
-  const [storyArray, setStoryArray] = useState(getStoryArray());
-  const [page, setPage] = useState(0);
-
-  /**
-   * This function will pull up the next paragraph of the current article or move on
-   * to the next one once the user is finished with this article.
-   */
-  const nextParagraph = () => {
-    if (storyArray.length - 1 === page) {
-      setStoryArray(getStoryArray());
-      setPage(0);
-    } else {
-      setPage(page + 1);
-    }
-  };
-
   const dispatch = useDispatch();
+
+  const { paragraph, nextParagraph, onTimeComplete, setSkipped } =
+    useReadingProblems({ navigation, route });
 
   const nextSection = () => {
     Alert.alert(
@@ -70,6 +57,8 @@ export default function ReadingMain({ navigation, route }: Props) {
         {
           text: "Yes",
           onPress: () => {
+            setSkipped(true);
+            onTimeComplete();
             dispatch(unpause());
             navigation.navigate("TriviaMain");
           },
@@ -78,12 +67,6 @@ export default function ReadingMain({ navigation, route }: Props) {
       { cancelable: false },
     );
   };
-
-  const paragraph = storyArray[page];
-
-  const onTimeComplete = useCallback(() => {
-    navigation.navigate(...route.params.nextScreenArgs);
-  }, [navigation, route.params.nextScreenArgs]);
 
   return (
     <View style={styles.root}>

--- a/src/screens/Game/ReadingMain.tsx
+++ b/src/screens/Game/ReadingMain.tsx
@@ -8,7 +8,7 @@ import Text from "../../components/Text";
 import useReadingProblems from "../../hooks/useReadingProblems";
 import { RootStackParamList } from "../../types";
 import gameDescriptions from "../Stacks/gameDescriptions";
-import { unpause } from "../../redux/reducers/pauseReducer";
+import { pause, unpause } from "../../redux/reducers/pauseReducer";
 
 const styles = StyleSheet.create({
   root: {
@@ -48,6 +48,7 @@ export default function ReadingMain({ navigation, route }: Props) {
   });
 
   const nextSection = () => {
+    dispatch(pause());
     Alert.alert(
       "Skip Reading Section",
       "Are you sure you want to skip the Reading section?",
@@ -55,6 +56,7 @@ export default function ReadingMain({ navigation, route }: Props) {
         {
           text: "Cancel",
           style: "cancel",
+          onPress: () => dispatch(unpause()),
         },
         {
           text: "Yes",

--- a/src/screens/Game/ReadingMain.tsx
+++ b/src/screens/Game/ReadingMain.tsx
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const TOTAL_TIME = gameDescriptions.Reading.minutes * 5;
+const TOTAL_TIME = gameDescriptions.Reading.minutes * 60;
 type Props = NativeStackScreenProps<RootStackParamList, "ReadingMain">;
 
 export default function ReadingMain({ navigation, route }: Props) {


### PR DESCRIPTION
## Extract Reading Analytics from Gameplay and Add Skip Section

Issue Number(s): #187.

What does this PR change and why?
Replace the `Skip Article` button with the `Skip Section` button, as well as figure out a way to store the statistics of how many passages are read by the user, and whether they skipped the section or they completed it.

### Checklist

- [x] Remove the Skip Article Button
- [x] Add a Skip Section Button and Alert popup for confirmation
- [x] Add useReadingProblems hook to generate passages and monitor statistics
- [x] Calculate the number of passages read
- [x] Move onTimeComplete function to the useReadingProblems hook
- [x] Update onTimeComplete to create a reading statistics object from the metrics


### Critical Changes / Notes

- `navigation.navigate` -> `navigation.replace`
- `useReadingProblems `generates the paragraphs and statistics rather than `ReadingMain`
- `onTimeComplete` is in `useReadingProblems `now and takes in `skipped `as a parameter
- **BUG:** `ProgressBar` temporarily pauses when you click `Next Paragraph`

### Related PRs

- N/A

### Testing

Enumerate steps to test the functionality of your ticket. This should include edge cases and testing of error handling, if applicable.

1. Click 'Start Exercises' button
2. Complete Math section
3. Start Reading section
4. Complete Reading section OR click 'Skip Section' button
5. Check console to make sure `passagesRead` and `completed` statistics are correct