### PR TITLE
andy/216-redesign-pages-fix-reloading

### DIFF
--- a/src/components/ContinueButton.tsx
+++ b/src/components/ContinueButton.tsx
@@ -44,10 +44,8 @@ export default function ContinueButton({
         marginBottom: 20,
         backgroundColor: `${backgroundColor}`,
         borderRadius: 12,
-        justifyContent: "center",
-        alignItems: "center",
         // marginTop: "2.5%",
-        width: "92%",
+        width: "100%",
       }}
     />
   );

--- a/src/components/Home/ExerciseSubjects.tsx
+++ b/src/components/Home/ExerciseSubjects.tsx
@@ -108,13 +108,13 @@ const Subject: React.FC<SubjectProps> = ({
             style={styles.startButton}
             onPress={() => {
               if (subjectText === "Math") {
-                navigation.navigate("MathIntro");
+                navigation.navigate("MathOverview");
               } else if (subjectText === "Reading") {
-                navigation.navigate("ReadingIntro");
+                navigation.navigate("ReadingOverview");
               } else if (subjectText === "Writing") {
-                navigation.navigate("WritingIntro");
+                navigation.navigate("WritingOverview");
               } else if (subjectText === "Trivia") {
-                navigation.navigate("TriviaIntro");
+                navigation.navigate("TriviaOverview");
               }
             }}
           >

--- a/src/components/PauseButton.tsx
+++ b/src/components/PauseButton.tsx
@@ -14,14 +14,12 @@ import { RootState } from "../redux/rootReducer";
 type Props = {
   onPress?: (e: GestureResponderEvent) => void;
   maxSeconds: number;
-  onTimeComplete?: () => void;
   remainingTimeRef?: MutableRefObject<RemainingTimeGetter>;
 };
 
 export default function PauseButton({
   onPress,
   maxSeconds,
-  onTimeComplete,
   remainingTimeRef,
 }: Props) {
   const navigation =
@@ -55,19 +53,21 @@ export default function PauseButton({
   useEffect(() => {
     const timer = setInterval(() => {
       if (remainingTime <= 0) {
-        clearInterval(timer);
-        if (onTimeComplete) {
-          onTimeComplete();
-        }
+        setRemainingTime(remainingTime - 1);
+        // clearInterval(timer);
+        console.log(remainingTime);
       } else if (!paused) {
         setRemainingTime(remainingTime - 1);
       }
     }, 1000);
     return () => clearInterval(timer);
-  }, [remainingTime, setRemainingTime, paused, onTimeComplete]);
+  }, [remainingTime, setRemainingTime, paused]);
 
   const seconds = remainingTime % 60;
-  const minutes = Math.floor(remainingTime / 60);
+  const minutes =
+    remainingTime < 0
+      ? Math.ceil(remainingTime / 60)
+      : Math.floor(remainingTime / 60);
 
   return (
     <TouchableOpacity
@@ -94,7 +94,10 @@ export default function PauseButton({
           marginLeft: 10,
         }}
       >
-        {minutes}:{seconds.toString().padStart(2, "0")}
+        {remainingTime < 0 ? `+${-minutes}` : minutes}:
+        {remainingTime < 0
+          ? (-seconds).toString().padStart(2, "0")
+          : seconds.toString().padStart(2, "0")}
       </Text>
     </TouchableOpacity>
   );

--- a/src/components/PauseButton.tsx
+++ b/src/components/PauseButton.tsx
@@ -1,17 +1,29 @@
-import { useCallback } from "react";
+/* eslint-disable no-param-reassign */
+import { useCallback, MutableRefObject, useEffect, useState } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { Button } from "react-native-elements";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { GestureResponderEvent } from "react-native-modal";
-import { RootStackParamList } from "../types";
+import { TouchableOpacity, Text } from "react-native";
+import FontAwesome5 from "react-native-vector-icons/FontAwesome5";
+import { RootStackParamList, RemainingTimeGetter } from "../types";
 import { pause } from "../redux/reducers/pauseReducer";
+
+import { RootState } from "../redux/rootReducer";
 
 type Props = {
   onPress?: (e: GestureResponderEvent) => void;
+  maxSeconds: number;
+  onTimeComplete?: () => void;
+  remainingTimeRef?: MutableRefObject<RemainingTimeGetter>;
 };
 
-export default function PauseButton({ onPress }: Props) {
+export default function PauseButton({
+  onPress,
+  maxSeconds,
+  onTimeComplete,
+  remainingTimeRef,
+}: Props) {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const dispatch = useDispatch();
@@ -29,20 +41,61 @@ export default function PauseButton({ onPress }: Props) {
     [onPress, navigation, dispatch],
   );
 
+  const [remainingTime, setRemainingTime] = useState(maxSeconds);
+  const paused = useSelector<RootState>(
+    (state) => state.paused.paused,
+  ) as boolean;
+
+  useEffect(() => {
+    if (remainingTimeRef) {
+      remainingTimeRef.current = { getRemainingTime: () => remainingTime };
+    }
+  }, [remainingTimeRef, remainingTime]);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (remainingTime <= 0) {
+        clearInterval(timer);
+        if (onTimeComplete) {
+          onTimeComplete();
+        }
+      } else if (!paused) {
+        setRemainingTime(remainingTime - 1);
+      }
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [remainingTime, setRemainingTime, paused, onTimeComplete]);
+
+  const seconds = remainingTime % 60;
+  const minutes = Math.floor(remainingTime / 60);
+
   return (
-    <Button
+    <TouchableOpacity
+      accessibilityRole="button"
+      style={{
+        paddingHorizontal: 22,
+        paddingVertical: 6,
+        backgroundColor: "#E3EAFC",
+        borderRadius: 12,
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        width: "32%",
+        justifyContent: "space-between",
+      }}
       onPress={onPressButton}
-      title="Pause"
-      titleStyle={{
-        color: "black",
-        fontSize: 16,
-      }}
-      buttonStyle={{
-        backgroundColor: "transparent",
-        marginRight: 10,
-        borderColor: "#005AA3",
-      }}
-      type="clear"
-    />
+    >
+      <FontAwesome5 name="pause" size={18} color="#2B3674" />
+      <Text
+        style={{
+          color: "#2B3674",
+          fontWeight: 500,
+          fontSize: 20,
+          marginLeft: 10,
+        }}
+      >
+        {minutes}:{seconds.toString().padStart(2, "0")}
+      </Text>
+    </TouchableOpacity>
   );
 }

--- a/src/screens/CompletionSummary/CompletionSummaryScreen.tsx
+++ b/src/screens/CompletionSummary/CompletionSummaryScreen.tsx
@@ -84,7 +84,7 @@ function CompletionSummaryScreen({ navigation }: Props) {
           averageTimePerQuestion={gameDetails.trivia.timePerQuestion}
           statColor="#34BC99"
         ></SubjectComponent>
-        <View style={{ width: "100%" }}>
+        <View style={{ width: "92%" }}>
           <ContinueButton
             title="Return home"
             titleColor="white"

--- a/src/screens/Game/GameFinished.tsx
+++ b/src/screens/Game/GameFinished.tsx
@@ -18,7 +18,7 @@ export default function GameFinished({ navigation, route }: Props) {
         alignItems: "center",
         justifyContent: "space-between",
         paddingTop: "30%",
-        paddingBottom: "15%",
+        paddingBottom: "6%",
         backgroundColor: "#008AFC",
       }}
     >
@@ -49,7 +49,7 @@ export default function GameFinished({ navigation, route }: Props) {
           You finished one section.
         </Text>
       </View>
-      <View style={{ alignItems: "center", width: "185%" }}>
+      <View style={{ alignItems: "center", width: "155%" }}>
         <ContinueButton
           title="Resume"
           backgroundColor="white"

--- a/src/screens/Game/MathMain/MathMain.tsx
+++ b/src/screens/Game/MathMain/MathMain.tsx
@@ -31,6 +31,9 @@ function MathMain({ route, navigation }: Props) {
     (waitSeconds: number) => {
       setButtonsDisabled(true);
       setTimeout(() => {
+        if (remainingTimeRef.current.getRemainingTime() <= 0) {
+          onTimeComplete();
+        }
         setButtonsDisabled(false);
         setSkipped(false);
         getNewProblem();
@@ -38,7 +41,7 @@ function MathMain({ route, navigation }: Props) {
           remainingTimeRef.current.getRemainingTime();
       }, waitSeconds * 1000);
     },
-    [getNewProblem, remainingTimeRef],
+    [getNewProblem, remainingTimeRef, onTimeComplete],
   );
 
   const onPressChoice = (choiceValue: number) => {
@@ -63,11 +66,11 @@ function MathMain({ route, navigation }: Props) {
   };
 
   const onPressSkip = () => {
-    if (remainingTimeRef.current.getRemainingTime() === 0) {
-      onTimeComplete();
-    }
-
     updateStatsOnSkip();
+    if (remainingTimeRef.current.getRemainingTime() <= 0) {
+      onTimeComplete();
+      return;
+    }
     resetAndNewProblem(2);
   };
 
@@ -127,7 +130,6 @@ function MathMain({ route, navigation }: Props) {
           <PauseButton
             maxSeconds={TOTAL_TIME}
             remainingTimeRef={remainingTimeRef}
-            onTimeComplete={onTimeComplete}
           />
         </View>
         {/* <ProgressBar

--- a/src/screens/Game/MathMain/MathMain.tsx
+++ b/src/screens/Game/MathMain/MathMain.tsx
@@ -1,16 +1,15 @@
 import React, { useState, useRef, useCallback } from "react";
-import { View } from "react-native";
+import { TouchableOpacity, View } from "react-native";
 import { Button } from "react-native-elements";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import "react-native-gesture-handler";
 import Toast from "react-native-toast-message";
 
-import CustomButton from "../../../components/Button";
-import ProgressBar from "../../../components/ProgressBar";
 import Text from "../../../components/Text";
 import useMathProblems, { TOTAL_TIME } from "../../../hooks/useMathProblems";
 import { RemainingTimeGetter, RootStackParamList } from "../../../types";
 import styles from "./MathMain.style";
+import PauseButton from "../../../components/PauseButton";
 
 type Props = NativeStackScreenProps<RootStackParamList, "MathMain">;
 
@@ -94,27 +93,122 @@ function MathMain({ route, navigation }: Props) {
   ));
 
   return (
-    <View style={styles.root}>
-      <ProgressBar
-        maxSeconds={TOTAL_TIME}
-        remainingTimeRef={remainingTimeRef}
-        redThreshold={60}
-        onTimeComplete={onTimeComplete}
-      />
-      <Toast visibilityTime={1000} position="bottom" bottomOffset={120} />
-      <View style={styles.textContainer}>
-        <Text style={styles.title}>Tap the answer to the math problem.</Text>
-        <Text style={styles.expressionText}>{problem.expression}</Text>
+    <View
+      style={{
+        display: "flex",
+        alignContent: "center",
+        justifyContent: "space-between",
+        padding: 20,
+        paddingTop: "16%",
+        paddingHorizontal: "4%",
+        paddingBottom: "6%",
+        backgroundColor: "white",
+        height: "100%",
+      }}
+    >
+      <View>
+        <View
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "space-between",
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: "bold",
+              color: "#2B3674",
+              alignSelf: "left",
+            }}
+          >
+            Math
+          </Text>
+          <PauseButton
+            maxSeconds={TOTAL_TIME}
+            remainingTimeRef={remainingTimeRef}
+            onTimeComplete={onTimeComplete}
+          />
+        </View>
+        {/* <ProgressBar
+          maxSeconds={TOTAL_TIME}
+          remainingTimeRef={remainingTimeRef}
+          redThreshold={60}
+          onTimeComplete={onTimeComplete}
+        /> */}
+        {/* <Toast visibilityTime={1000} position="bottom" bottomOffset={120} /> */}
+        <View
+          style={{
+            borderWidth: 1,
+            borderColor: "#E3EAFC",
+            padding: 16,
+            borderRadius: 12,
+            marginTop: "8%",
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: "bold",
+              color: "#2B3674",
+              textAlign: "center",
+            }}
+          >
+            {"Tap the answer to the\nmath problem."}
+          </Text>
+        </View>
+        <View
+          style={{
+            borderWidth: 1,
+            borderColor: "#E3EAFC",
+            paddingVertical: 40,
+            paddingHorizontal: 16,
+            borderRadius: 12,
+            marginTop: "8%",
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 48,
+              fontWeight: "bold",
+              color: "#EA4335",
+              textAlign: "center",
+            }}
+          >
+            {problem.expression}
+          </Text>
+        </View>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={onPressSkip}
+          style={{
+            alignSelf: "center",
+            marginTop: "8%",
+          }}
+        >
+          <Text
+            style={{
+              textAlign: "center",
+              color: "#2B3674",
+              fontSize: 24,
+              fontWeight: 600,
+              textDecorationLine: "underline",
+            }}
+          >
+            Skip
+          </Text>
+        </TouchableOpacity>
       </View>
-      <View style={styles.container}>{choices}</View>
-      <CustomButton
-        title="Skip"
-        buttonStyle={{
-          marginBottom: "10%",
+      <View
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "space-between",
+          marginBottom: "30%",
         }}
-        disabled={buttonsDisabled}
-        onPress={onPressSkip}
-      />
+      >
+        {choices}
+      </View>
     </View>
   );
 }

--- a/src/screens/Game/MathMain/MathOverview.tsx
+++ b/src/screens/Game/MathMain/MathOverview.tsx
@@ -1,52 +1,105 @@
-import { AVPlaybackSource } from "expo-av";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { View, StyleSheet } from "react-native";
-import Button from "../../../components/Button";
+import { View } from "react-native";
+import FontAwesome5 from "react-native-vector-icons/FontAwesome5";
 import Text from "../../../components/Text";
 import "react-native-gesture-handler";
-import useSound from "../../../hooks/useSound";
-import { RootStackParamList, SoundSetting } from "../../../types";
+import { RootStackParamList } from "../../../types";
+import ContinueButton from "../../../components/ContinueButton";
+import gameDescriptions from "../../Stacks/gameDescriptions";
 
-const sound = require("../../../assets/intro.mp3") as AVPlaybackSource;
-
-const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    alignContent: "center",
-    justifyContent: "space-between",
-    padding: 20,
-    paddingTop: 100,
-    backgroundColor: "white",
-  },
-  text: {
-    fontSize: 25,
-    fontWeight: "bold",
-    textAlign: "center",
-    paddingTop: 50,
-  },
-  time: {
-    fontSize: 20,
-    paddingTop: 200,
-    textAlign: "center",
-  },
-});
+// const sound = require("../../../assets/intro.mp3") as AVPlaybackSource;
 
 type Props = NativeStackScreenProps<RootStackParamList, "GameOverview">;
 
 function MathOverview({ navigation }: Props) {
-  const { unloadSound } = useSound(sound, SoundSetting.voiceOverOn);
+  // const { unloadSound } = useSound(sound, SoundSetting.voiceOverOn);
 
   return (
-    <View style={styles.root}>
-      <Text style={styles.text}>You will be completing Math exercises.</Text>
-      <Text style={styles.time}>Total time: 30 minutes</Text>
-      <Button
-        title="Begin"
-        onPress={() => {
-          unloadSound();
-          navigation.navigate("MathIntro");
+    <View
+      style={{
+        flex: 1,
+        alignContent: "center",
+        justifyContent: "space-between",
+        paddingHorizontal: "4%",
+        paddingBottom: "6%",
+        paddingTop: "16%",
+        backgroundColor: "white",
+      }}
+    >
+      <View
+        style={{
+          alignItems: "center",
         }}
-        buttonStyle={{ marginBottom: 30 }}
+      >
+        <Text
+          style={{
+            fontSize: 24,
+            fontWeight: "bold",
+            color: "#2B3674",
+            alignSelf: "left",
+          }}
+        >
+          Math
+        </Text>
+        <View
+          style={{
+            alignSelf: "center",
+            paddingVertical: 64,
+            paddingHorizontal: 32,
+            borderWidth: 1,
+            borderColor: "#E3EAFC",
+            borderRadius: 12,
+            width: "100%",
+            marginVertical: 24,
+            alignItems: "center",
+          }}
+        >
+          <FontAwesome5 name="square-root-alt" size={50} color="#EA4335" />
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: "bold",
+              color: "#2B3674",
+              textAlign: "center",
+              marginTop: 12,
+              lineHeight: 32,
+            }}
+          >
+            {"Solve math questions\nas fast as you can."}
+          </Text>
+        </View>
+        <View
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            paddingHorizontal: 22,
+            paddingVertical: 6,
+            backgroundColor: "#E3EAFC",
+            borderRadius: 12,
+          }}
+        >
+          <FontAwesome5 name="stopwatch" size={20} color="#2B3674" />
+          <Text
+            style={{
+              fontSize: 20,
+              fontWeight: 500,
+              color: "#2B3674",
+              textAlign: "center",
+              marginLeft: 10,
+            }}
+          >
+            {`${gameDescriptions.Math.minutes.toString()} minutes`}
+          </Text>
+        </View>
+      </View>
+      <ContinueButton
+        title="Continue"
+        backgroundColor="#EA4335"
+        titleColor="white"
+        onPressFn={() => {
+          navigation.navigate("MathMain");
+        }}
       />
     </View>
   );

--- a/src/screens/Game/Pause.tsx
+++ b/src/screens/Game/Pause.tsx
@@ -1,27 +1,33 @@
 import React from "react";
-import { Alert, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import "react-native-gesture-handler";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useDispatch } from "react-redux";
 import { useNavigation } from "@react-navigation/native";
+import FontAwesome5 from "react-native-vector-icons/FontAwesome5";
 import { unpause } from "../../redux/reducers/pauseReducer";
-import Button from "../../components/Button";
+// import Button from "../../components/Button";
 import Text from "../../components/Text";
 import { RootStackParamList } from "../../types";
+import ContinueButton from "../../components/ContinueButton";
 
 const styles = StyleSheet.create({
   root: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    backgroundColor: "white",
+    display: "flex",
+    alignContent: "center",
+    justifyContent: "space-between",
     padding: 20,
+    paddingTop: "16%",
+    backgroundColor: "white",
+    height: "100%",
   },
   text: {
-    fontWeight: "bold",
     fontSize: 24,
-    marginBottom: 20,
+    fontWeight: "bold",
+    color: "#2B3674",
     textAlign: "center",
+    marginTop: 12,
+    lineHeight: 32,
   },
   button: {
     marginTop: 20,
@@ -40,18 +46,46 @@ function Pause() {
 
   return (
     <View style={styles.root}>
-      <Text
-        style={styles.text}
-      >{`You're just getting started. Keep going!`}</Text>
-      <Button
+      <View>
+        <Text style={styles.text}>Exercise Paused</Text>
+        <View
+          style={{
+            display: "flex",
+            borderWidth: 1,
+            borderColor: "#E3EAFC",
+            paddingVertical: 64,
+            paddingHorizontal: 32,
+            borderRadius: 12,
+            marginTop: "10%",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <View
+            style={{
+              borderWidth: 6,
+              borderRadius: 100,
+              padding: 10,
+              borderColor: "#008AFC",
+            }}
+          >
+            <FontAwesome5 name="pause" size={22} color="#008AFC" />
+          </View>
+          <Text
+            style={styles.text}
+          >{`You're just getting\nstarted. Keep going!`}</Text>
+        </View>
+      </View>
+      <ContinueButton
         title="Resume"
-        buttonStyle={styles.button}
-        onPress={() => {
+        backgroundColor="#008AFC"
+        titleColor="white"
+        onPressFn={() => {
           dispatch(unpause());
           navigation.goBack();
         }}
       />
-      <Button
+      {/* <Button
         title="Quit"
         buttonStyle={styles.quit}
         titleStyle={{ color: "red" }}
@@ -75,7 +109,7 @@ function Pause() {
             { cancelable: false },
           )
         }
-      />
+      /> */}
     </View>
   );
 }

--- a/src/screens/Game/SectionSummary/SectionSummary.tsx
+++ b/src/screens/Game/SectionSummary/SectionSummary.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, Text, ScrollView } from "react-native";
+import { View, Text } from "react-native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import FontAwesome5 from "react-native-vector-icons/FontAwesome5";
 import { useSelector } from "react-redux";
@@ -177,72 +177,85 @@ export default function SectionSummary({ route }: Props) {
   }
 
   return (
-    <ScrollView style={{ backgroundColor: "#FFF", height: "100%" }}>
+    <View style={{ backgroundColor: "#FFF", height: "100%" }}>
       <View
         style={{
+          display: "flex",
+          justifyContent: "space-between",
           alignItems: "center",
-          paddingVertical: "14%",
+          paddingTop: "16%",
+          paddingBottom: "6%",
           width: "100%",
           alignContent: "space-between",
+          height: "100%",
         }}
       >
-        <Text
+        <View
           style={{
-            alignSelf: "flex-start",
-            paddingLeft: "4%",
-            fontSize: 26,
-            fontWeight: 600,
-            paddingTop: "4%",
-            paddingBottom: "5%",
+            alignItems: "center",
+            width: "100%",
+            alignContent: "space-between",
           }}
         >
-          Completion summary
-        </Text>
-        {"questionsAttempted" in subjectDetails ? (
-          <OneLineComponent
-            icon={
-              <FontAwesome5 name="question-circle" size={24} color={color} />
-            }
-            title="Questions Completed"
-            stat={questions}
-            statColor={color}
-          />
-        ) : (
-          <></>
-        )}
-        {"timePerQuestion" in subjectDetails ||
-        "timePerPassage" in subjectDetails ? (
-          <TwoLineComponent
-            icon={<FontAwesome5 name="clock" size={24} color={color} />}
-            title="Total time spent"
-            stat={`${Math.floor((questions * timePer) / 60)} min ${
-              questions * timePer - 60 * Math.floor((questions * timePer) / 60)
-            } sec`}
-            statColor={color}
-          />
-        ) : (
-          <></>
-        )}
-        {"timePerQuestion" in subjectDetails &&
-        subject !== "writing" &&
-        subject !== "reading" ? (
-          <TwoLineComponent
-            icon={<FontAwesome5 name="clock" size={24} color={color} />}
-            title="Average time per question"
-            stat={`${Math.floor(timePer / 60)} min ${
-              timePer - 60 * Math.floor(timePer / 60)
-            } sec`}
-            statColor={color}
-          />
-        ) : (
-          <></>
-        )}
-        {/* {"subjects" in subjectDetails ? (
-          <PieChartComponent triviaSubjects={subjectDetails.subjects} />
-        ) : (
-          <></>
-        )} */}
-        <View style={{ width: "100%" }}>
+          <Text
+            style={{
+              alignSelf: "flex-start",
+              paddingLeft: "4%",
+              fontSize: 26,
+              fontWeight: 600,
+              paddingTop: "4%",
+              paddingBottom: "5%",
+            }}
+          >
+            Completion summary
+          </Text>
+          {"questionsAttempted" in subjectDetails ? (
+            <OneLineComponent
+              icon={
+                <FontAwesome5 name="question-circle" size={24} color={color} />
+              }
+              title="Questions Completed"
+              stat={questions}
+              statColor={color}
+            />
+          ) : (
+            <></>
+          )}
+          {"timePerQuestion" in subjectDetails ||
+          "timePerPassage" in subjectDetails ? (
+            <TwoLineComponent
+              icon={<FontAwesome5 name="clock" size={24} color={color} />}
+              title="Total time spent"
+              stat={`${Math.floor((questions * timePer) / 60)} min ${
+                questions * timePer -
+                60 * Math.floor((questions * timePer) / 60)
+              } sec`}
+              statColor={color}
+            />
+          ) : (
+            <></>
+          )}
+          {"timePerQuestion" in subjectDetails &&
+          subject !== "writing" &&
+          subject !== "reading" ? (
+            <TwoLineComponent
+              icon={<FontAwesome5 name="clock" size={24} color={color} />}
+              title="Average time per question"
+              stat={`${Math.floor(timePer / 60)} min ${
+                timePer - 60 * Math.floor(timePer / 60)
+              } sec`}
+              statColor={color}
+            />
+          ) : (
+            <></>
+          )}
+          {/* {"subjects" in subjectDetails ? (
+            <PieChartComponent triviaSubjects={subjectDetails.subjects} />
+          ) : (
+            <></>
+          )} */}
+        </View>
+        <View style={{ width: "92%" }}>
           <ContinueButton
             title="Continue"
             titleColor="#FFF"
@@ -250,6 +263,6 @@ export default function SectionSummary({ route }: Props) {
           />
         </View>
       </View>
-    </ScrollView>
+    </View>
   );
 }

--- a/src/screens/Game/TriviaMain/TriviaMain.tsx
+++ b/src/screens/Game/TriviaMain/TriviaMain.tsx
@@ -1,74 +1,74 @@
 import { useState, useCallback, useRef } from "react";
-import { StyleSheet, View } from "react-native";
+import { View, TouchableOpacity } from "react-native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import "react-native-gesture-handler";
-import Button from "../../../components/Button";
-import ProgressBar from "../../../components/ProgressBar";
 import Text from "../../../components/Text";
 import gameDescriptions from "../../Stacks/gameDescriptions";
 import { RemainingTimeGetter, RootStackParamList } from "../../../types";
+import PauseButton from "../../../components/PauseButton";
+import ContinueButton from "../../../components/ContinueButton";
 
 import useTriviaProblems from "../../../hooks/useTriviaProblems";
 
-const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: 15,
-    paddingHorizontal: 20,
-    backgroundColor: "white",
-  },
-  instructionText: {
-    paddingTop: 75,
-    paddingHorizontal: 20,
-    fontSize: 30,
-    fontWeight: "bold",
-    textAlign: "center",
-  },
-  questionText: {
-    fontSize: 24,
-    textAlign: "center",
-  },
-  answerText: {
-    fontSize: 25,
-    fontWeight: "bold",
-    textAlign: "center",
-  },
-  actualAnswerText: {
-    fontSize: 25,
-    textAlign: "center",
-  },
-  container: {
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  showButton: {
-    marginBottom: 20,
-  },
-  buttonContainer: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-  },
-  yesButton: {
-    marginBottom: 20,
-    marginRight: 10,
-    width: 150,
-  },
-  noButton: {
-    marginBottom: 20,
-    marginLeft: 10,
-    width: 150,
-  },
-  buttonTitle: {
-    color: "white",
-  },
-  showButtonTitle: {
-    alignSelf: "center",
-    fontWeight: "bold",
-    color: "white",
-  },
-});
+// const styles = StyleSheet.create({
+//   root: {
+//     flex: 1,
+//     justifyContent: "space-between",
+//     alignItems: "center",
+//     paddingVertical: 15,
+//     paddingHorizontal: 20,
+//     backgroundColor: "white",
+//   },
+//   instructionText: {
+//     paddingTop: 75,
+//     paddingHorizontal: 20,
+//     fontSize: 30,
+//     fontWeight: "bold",
+//     textAlign: "center",
+//   },
+//   questionText: {
+//     fontSize: 24,
+//     textAlign: "center",
+//   },
+//   answerText: {
+//     fontSize: 25,
+//     fontWeight: "bold",
+//     textAlign: "center",
+//   },
+//   actualAnswerText: {
+//     fontSize: 25,
+//     textAlign: "center",
+//   },
+//   container: {
+//     alignItems: "center",
+//     justifyContent: "center",
+//   },
+//   showButton: {
+//     marginBottom: 20,
+//   },
+//   buttonContainer: {
+//     flexDirection: "row",
+//     justifyContent: "space-between",
+//   },
+//   yesButton: {
+//     marginBottom: 20,
+//     marginRight: 10,
+//     width: 150,
+//   },
+//   noButton: {
+//     marginBottom: 20,
+//     marginLeft: 10,
+//     width: 150,
+//   },
+//   buttonTitle: {
+//     color: "white",
+//   },
+//   showButtonTitle: {
+//     alignSelf: "center",
+//     fontWeight: "bold",
+//     color: "white",
+//   },
+// });
 
 const TOTAL_TIME = gameDescriptions.Trivia.minutes * 60;
 type Props = NativeStackScreenProps<RootStackParamList, "TriviaMain">;
@@ -104,49 +104,174 @@ export default function TriviaScreen({ navigation, route }: Props) {
   );
 
   return (
-    <View style={styles.root}>
+    <View
+      style={{
+        display: "flex",
+        alignContent: "center",
+        justifyContent: "space-between",
+        padding: 20,
+        paddingTop: "16%",
+        paddingHorizontal: "4%",
+        paddingBottom: "6%",
+        backgroundColor: "white",
+        height: "100%",
+      }}
+    >
       <View>
-        <ProgressBar
-          maxSeconds={TOTAL_TIME}
-          remainingTimeRef={remainingTimeRef}
-          redThreshold={60}
-          onTimeComplete={onTimeComplete}
-        />
-        <Text style={styles.instructionText}>
-          Write the question, then your answer
-        </Text>
-      </View>
-      <Text style={styles.questionText}>{problem.question}</Text>
-
-      {answered ? (
-        <>
-          <Text style={styles.answerText}>Answer:</Text>
-          <Text style={styles.actualAnswerText}>{String(problem.answer)}</Text>
-          <Text style={styles.questionText}>Did you answer it correctly?</Text>
-
-          <View style={styles.buttonContainer}>
-            <Button
-              title="Yes"
-              buttonStyle={styles.yesButton}
-              titleStyle={styles.buttonTitle}
-              onPress={() => onAnswerClick(true)}
-            />
-            <Button
-              title="No"
-              buttonStyle={styles.noButton}
-              titleStyle={styles.buttonTitle}
-              onPress={() => onAnswerClick(false)}
-            />
+        <View
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "space-between",
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: "bold",
+              color: "#2B3674",
+              alignSelf: "left",
+            }}
+          >
+            Trivia
+          </Text>
+          <PauseButton
+            maxSeconds={TOTAL_TIME}
+            remainingTimeRef={remainingTimeRef}
+            onTimeComplete={onTimeComplete}
+          />
+        </View>
+        <View
+          style={{
+            borderWidth: 1,
+            borderColor: "#E3EAFC",
+            borderRadius: 12,
+            marginTop: "8%",
+            display: "flex",
+            justifyContent: "center",
+            paddingVertical: 64,
+            paddingHorizontal: 32,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: "bold",
+              color: "#34BC99",
+              textAlign: "center",
+              marginBottom: 12,
+            }}
+          >
+            Question:
+          </Text>
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: 600,
+              color: "#2B3674",
+              textAlign: "center",
+              lineHeight: 32,
+            }}
+          >
+            {problem.question}
+          </Text>
+        </View>
+        {answered ? (
+          <View
+            style={{
+              borderWidth: 1,
+              borderColor: "#E3EAFC",
+              borderRadius: 12,
+              marginTop: "8%",
+              paddingVertical: 64,
+              paddingHorizontal: 32,
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 24,
+                fontWeight: "bold",
+                color: "#34BC99",
+                textAlign: "center",
+                marginBottom: 12,
+              }}
+            >
+              Answer:
+            </Text>
+            <Text
+              style={{
+                fontSize: 24,
+                fontWeight: 600,
+                color: "#2B3674",
+                textAlign: "center",
+                lineHeight: 32,
+              }}
+            >
+              {String(problem.answer)}
+            </Text>
           </View>
-        </>
-      ) : (
-        <Button
-          title="Show Answer"
-          buttonStyle={styles.showButton}
-          titleStyle={styles.showButtonTitle}
-          onPress={onPressShowButton}
-        />
-      )}
+        ) : (
+          <>
+            <View
+              style={{
+                borderWidth: 1,
+                borderColor: "#E3EAFC",
+                borderRadius: 12,
+                marginTop: "8%",
+              }}
+            >
+              <Text
+                style={{
+                  fontSize: 20,
+                  fontWeight: "bold",
+                  color: "#2B3674",
+                  textAlign: "center",
+                  padding: 16,
+                }}
+              >
+                Write down both the question and the answer
+              </Text>
+            </View>
+            <TouchableOpacity
+              accessibilityRole="button"
+              onPress={() => onAnswerClick(false)}
+              style={{
+                alignSelf: "center",
+                marginTop: "8%",
+              }}
+            >
+              <Text
+                style={{
+                  textAlign: "center",
+                  color: "#2B3674",
+                  fontSize: 24,
+                  fontWeight: 600,
+                  textDecorationLine: "underline",
+                }}
+              >
+                Skip
+              </Text>
+            </TouchableOpacity>
+          </>
+        )}
+      </View>
+      <View>
+        {answered ? (
+          <ContinueButton
+            title="Next"
+            backgroundColor="#34BC99"
+            titleColor="white"
+            onPressFn={() => onAnswerClick(true)}
+          />
+        ) : (
+          <ContinueButton
+            title="Show Answer"
+            backgroundColor="#34BC99"
+            titleColor="white"
+            onPressFn={onPressShowButton}
+          />
+        )}
+      </View>
     </View>
   );
 }

--- a/src/screens/Game/TriviaMain/TriviaMain.tsx
+++ b/src/screens/Game/TriviaMain/TriviaMain.tsx
@@ -83,9 +83,12 @@ export default function TriviaScreen({ navigation, route }: Props) {
   const remainingTimeRef = useRef<RemainingTimeGetter>();
 
   const nextProblem = useCallback(() => {
+    if (remainingTimeRef.current.getRemainingTime() <= 0) {
+      onTimeComplete();
+    }
     getNewProblem();
     setAnswered(false);
-  }, [getNewProblem]);
+  }, [getNewProblem, onTimeComplete]);
 
   const onPressShowButton = useCallback(() => {
     if (!answered) {
@@ -138,7 +141,6 @@ export default function TriviaScreen({ navigation, route }: Props) {
           <PauseButton
             maxSeconds={TOTAL_TIME}
             remainingTimeRef={remainingTimeRef}
-            onTimeComplete={onTimeComplete}
           />
         </View>
         <View

--- a/src/screens/Game/TriviaMain/TriviaOverview.tsx
+++ b/src/screens/Game/TriviaMain/TriviaOverview.tsx
@@ -1,52 +1,129 @@
-import { AVPlaybackSource } from "expo-av";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { View, StyleSheet } from "react-native";
-import Button from "../../../components/Button";
+import { View } from "react-native";
+import FontAwesome5 from "react-native-vector-icons/FontAwesome5";
 import Text from "../../../components/Text";
 import "react-native-gesture-handler";
-import useSound from "../../../hooks/useSound";
-import { RootStackParamList, SoundSetting } from "../../../types";
+import { RootStackParamList } from "../../../types";
+import ContinueButton from "../../../components/ContinueButton";
+import gameDescriptions from "../../Stacks/gameDescriptions";
 
-const sound = require("../../../assets/intro.mp3") as AVPlaybackSource;
+// const sound = require("../../../assets/intro.mp3") as AVPlaybackSource;
 
-const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    alignContent: "center",
-    justifyContent: "space-between",
-    padding: 20,
-    paddingTop: 100,
-    backgroundColor: "white",
-  },
-  text: {
-    fontSize: 25,
-    fontWeight: "bold",
-    textAlign: "center",
-    paddingTop: 50,
-  },
-  time: {
-    fontSize: 20,
-    paddingTop: 200,
-    textAlign: "center",
-  },
-});
+// const styles = StyleSheet.create({
+//   root: {
+//     flex: 1,
+//     alignContent: "center",
+//     justifyContent: "space-between",
+//     padding: 20,
+//     paddingTop: 100,
+//     backgroundColor: "white",
+//   },
+//   text: {
+//     fontSize: 25,
+//     fontWeight: "bold",
+//     textAlign: "center",
+//     paddingTop: 50,
+//   },
+//   time: {
+//     fontSize: 20,
+//     paddingTop: 200,
+//     textAlign: "center",
+//   },
+// });
 
 type Props = NativeStackScreenProps<RootStackParamList, "GameOverview">;
 
 function TriviaOverview({ navigation }: Props) {
-  const { unloadSound } = useSound(sound, SoundSetting.voiceOverOn);
+  // const { unloadSound } = useSound(sound, SoundSetting.voiceOverOn);
 
   return (
-    <View style={styles.root}>
-      <Text style={styles.text}>You will be completing Trivia exercises.</Text>
-      <Text style={styles.time}>Total time: 30 minutes</Text>
-      <Button
-        title="Begin"
-        onPress={() => {
-          unloadSound();
-          navigation.navigate("TriviaIntro");
+    <View
+      style={{
+        flex: 1,
+        alignContent: "center",
+        justifyContent: "space-between",
+        paddingHorizontal: "4%",
+        paddingBottom: "6%",
+        paddingTop: "16%",
+        backgroundColor: "white",
+      }}
+    >
+      <View
+        style={{
+          alignItems: "center",
         }}
-        buttonStyle={{ marginBottom: 30 }}
+      >
+        <Text
+          style={{
+            fontSize: 24,
+            fontWeight: "bold",
+            color: "#2B3674",
+            alignSelf: "left",
+          }}
+        >
+          Trivia
+        </Text>
+        <View
+          style={{
+            alignSelf: "center",
+            paddingVertical: 64,
+            paddingHorizontal: 32,
+            borderWidth: 1,
+            borderColor: "#E3EAFC",
+            borderRadius: 12,
+            width: "100%",
+            marginVertical: 24,
+            alignItems: "center",
+          }}
+        >
+          <FontAwesome5 name="question-circle" size={42} color="#34BC99" />
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: "bold",
+              color: "#2B3674",
+              textAlign: "center",
+              marginTop: 12,
+              lineHeight: 32,
+            }}
+          >
+            {
+              "Grab some paper and a\npencil with you. You're\ngoing to answer some\ntrivia questions."
+            }
+          </Text>
+        </View>
+        <View
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            paddingHorizontal: 22,
+            paddingVertical: 6,
+            backgroundColor: "#E3EAFC",
+            borderRadius: 12,
+          }}
+        >
+          <FontAwesome5 name="stopwatch" size={20} color="#2B3674" />
+          <Text
+            style={{
+              fontSize: 20,
+              fontWeight: 500,
+              color: "#2B3674",
+              textAlign: "center",
+              marginLeft: 10,
+            }}
+          >
+            {`${gameDescriptions.Trivia.minutes.toString()} minutes`}
+          </Text>
+        </View>
+      </View>
+      <ContinueButton
+        title="Continue"
+        backgroundColor="#34BC99"
+        titleColor="white"
+        onPressFn={() => {
+          navigation.navigate("TriviaMain");
+        }}
       />
     </View>
   );

--- a/src/screens/Home/HomeScreen.tsx
+++ b/src/screens/Home/HomeScreen.tsx
@@ -1,11 +1,11 @@
 import "react-native-gesture-handler";
-import React from "react";
+import React, { useEffect } from "react";
 import { View, Image, TouchableOpacity, Text } from "react-native";
 import PropTypes from "prop-types";
 import FeatherIcon from "react-native-vector-icons/Feather";
 import { AVPlaybackSource } from "expo-av";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 
 import { styles } from "./HomeScreen.styles";
 import { GameDetails, RootStackParamList } from "../../types";
@@ -17,6 +17,8 @@ import Subject from "../../components/Home/ExerciseSubjects";
 import { RootState } from "../../redux/rootReducer";
 import { AuthUser } from "../../redux/reducers/authReducer/types";
 
+import { resetAttempted } from "../../redux/reducers/gameDetailsReducer";
+
 const logo = require("../../assets/bei.jpg") as AVPlaybackSource;
 
 type Props = NativeStackScreenProps<RootStackParamList, "GameOverview">;
@@ -25,6 +27,11 @@ type Props = NativeStackScreenProps<RootStackParamList, "GameOverview">;
 // TODO: Remove the following eslint-disable rule after using navigation
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function HomeScreen({ navigation }: Props) {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(resetAttempted());
+  }, [dispatch]);
+
   const userInfo = useSelector<RootState>((state) => state.auth) as AuthUser;
   const gameDetails = useSelector<
     RootState,

--- a/src/screens/Stacks/GameStacks.tsx
+++ b/src/screens/Stacks/GameStacks.tsx
@@ -2,7 +2,7 @@ import MathMain from "../Game/MathMain/MathMain";
 import ReadingMain from "../Game/ReadingMain/ReadingMain";
 import TriviaMain from "../Game/TriviaMain/TriviaMain";
 import IntroOverlay from "../../components/OverLays/IntroOverlay";
-import PauseButton from "../../components/PauseButton";
+// import PauseButton from "../../components/PauseButton";
 import { GameTypes } from "../../types";
 import Stack from "./StackNavigator";
 import gameDescriptions from "./gameDescriptions";
@@ -51,9 +51,10 @@ Object.keys(GameTypes).forEach((game: GameTypes) => {
       name={gameDescription.game.name}
       component={gameComponents[game]}
       options={{
-        title: gameDescription.title,
-        headerBackVisible: false,
-        headerRight: () => <PauseButton />,
+        // title: gameDescription.title,
+        // headerBackVisible: false,
+        // headerRight: () => <PauseButton />,
+        headerShown: false,
       }}
       initialParams={{
         nextScreenArgs: gameDescription.game.nextScreenArgs,

--- a/src/screens/Stacks/generalDescriptions.ts
+++ b/src/screens/Stacks/generalDescriptions.ts
@@ -35,6 +35,7 @@ const generalDescriptions: ScreenDescription[] = [
     title: "Paused",
     options: {
       animationTypeForReplace: "pop",
+      headerShown: false,
     },
   },
   {
@@ -58,6 +59,7 @@ const generalDescriptions: ScreenDescription[] = [
     name: "MathOverview",
     component: MathOverview,
     title: "Math Exercises",
+    options: { headerShown: false },
   },
   {
     name: "ReadingOverview",
@@ -73,6 +75,7 @@ const generalDescriptions: ScreenDescription[] = [
     name: "TriviaOverview",
     component: TriviaOverview,
     title: "Trivia Exercises",
+    options: { headerShown: false },
   },
 ];
 


### PR DESCRIPTION
## 216

Issue Number(s): #216 .

What does this PR change and why?

- Pause button component updated to reflect Figma and contain timer
- Pause page redesigned to reflect Figma
- Math page redesigned to reflect Figma
- Trivia page redesigned to reflect Figma
- Reset attempted every time app is opened
- Add extra time functionality

### Checklist

- [x] Math Pages Updated
- [x] Trivia Pages Updated
- [x] Pause Page Updated
- [x] Refresh analytics more frequently.

### Critical Changes / Notes

- Math equations may overflow box (decrease font size?)
- Trivia may overflow page (decrease vertical padding?)
- I was not able to implement the shadows from the Figma.
- Extra time functionality only in Math and Trivia while Shivani works on Writing and Reading

### Related PRs

- None

### Testing

Go through each page to ensure it correctly reflects the Figma redesigns. Ensure each page redirects correctly. Go through math and trivia questions to ensure there is no overflow in the design. Watch count down to ensure extra time is displayed properly.